### PR TITLE
Start looking for executable from buffer path not cwd

### DIFF
--- a/autoload/nrun.vim
+++ b/autoload/nrun.vim
@@ -39,8 +39,6 @@ function! nrun#Which(cmd, ...)
 			let l:execPath = fnamemodify(l:cwd . '/node_modules/.bin/' . a:cmd, ':p')
 			if executable(l:execPath)
 				return l:execPath
-			else
-				break
 			endif
 		endif
 		let l:cwd = resolve(l:cwd . '/..')

--- a/autoload/nrun.vim
+++ b/autoload/nrun.vim
@@ -31,7 +31,7 @@ function! nrun#Which(cmd, ...)
 		endif
 		unlet l:optType
 	endif
-	let l:cwd = getcwd()
+	let l:cwd = expand("%:p:h")
 	let l:rp = fnamemodify('/', ':p')
 	let l:hp = fnamemodify('~/', ':p')
 	while l:cwd != l:hp && l:cwd != l:rp


### PR DESCRIPTION
I have a couple of projects sitting under my cwd so eslint would not get found.

Not sure if this follows best practices or is even helpful to you, but thought I would put it out there.
